### PR TITLE
release: v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ work yet, regardless of what the source contains.
 
 ## [Unreleased]
 
+Nothing yet.
+
+## [0.2.0] - 2026-07-30
+
 Two more screens, the container facts the collector was already reading, and a way to
 watch one process together with everything it spawned.
 
@@ -29,7 +33,10 @@ watch one process together with everything it spawned.
   capacity with the resulting wear, pack temperature, and draw in watts. Plus a thermal
   sensor panel: those readings previously reached the screen as a single figure in the
   Overview header. A machine with no battery says so once, in the panel label, rather than
-  filling a screen with placeholders.
+  filling a screen with placeholders. **On macOS, cycles, capacity, wear, pack temperature
+  and watts all read `n/a`**: they live in the undocumented `AppleSmartBattery` registry
+  properties that §9.3 forbids this build from reading. The charge, the state and the time
+  remaining are real; the rest is honest absence, and the Linux collector reports all of it.
 * **The Linux battery collector**, from `/sys/class/power_supply/*` on the medium tier.
   `docs/platform-support.md` had been promising it. The system battery is picked by
   `type == Battery` with `scope` absent or `System`, which is what excludes the charger and
@@ -111,8 +118,10 @@ It had two panels and thirty blank rows. It now has four.
 
 #### Pressure escalations are announced
 
-* **A Pressure Radar signal crossing into `watch` or `critical` now produces a notice**
-  quoting the diagnostics engine's own rule text, not a paraphrase. An unavailable signal is
+* **A Pressure Radar signal changing state now produces a notice** quoting the diagnostics
+  engine's own rule text, not a paraphrase. Recoveries are announced too, at `info`
+  severity, because a signal that goes quiet without a word looks the same as one that
+  stopped being collected. An unavailable signal is
   never a de-escalation: it clears the remembered state, so the samples either side of a
   permission error cannot be stitched into a change that never happened.
 * **`diagnostics.bell_on_critical`** (default `false`) rings the terminal bell once per
@@ -132,18 +141,61 @@ It had two panels and thirty blank rows. It now has four.
   beside it. Also breaking for library users.
 * **`LinuxEnrichment::cgroup_cpu_limit` returns a `MetricState<CpuQuota>`** instead of an
   `Option<CpuMax>`, and `MeminfoSnapshot::to_snapshot` takes the group's charge alongside
-  its limit. `CpuSnapshot` and `MemorySnapshot` each gained a field, which breaks
-  struct-literal construction outside the collectors.
-* **A cgroup limit read that has gone stale still bounds the machine.** Both
-  `CpuSnapshot::effective_cores` and `MemorySnapshot::effective_limit_bytes` now accept a
-  stale reading, which is the one place this codebase deliberately breaks its own "fresh
-  values for calculations" rule. A limit is configuration, not a measurement: if the last
-  good read said 2 GiB and this tick's failed, falling back to the host's 64 GiB advertises
-  62 GiB of headroom that does not exist.
-* **Storage shows one row per device rather than one per mount point**, so an APFS Mac no
-  longer lists the same disk four times with the same figures.
+  its limit. The fields those changes added are in the consolidated list below.
+* **`MemorySnapshot::effective_limit_bytes` now accepts a stale cgroup reading**, which is
+  the one place this codebase deliberately breaks its own "fresh values for calculations"
+  rule. A limit is configuration, not a measurement: if the last good read said 2 GiB and
+  this tick's failed, falling back to the host's 64 GiB advertises 62 GiB of headroom that
+  does not exist. `CpuSnapshot::effective_cores` is its new counterpart and follows the same
+  rule; it is new in this release rather than changed.
+
+* **The JSON export schema is version `2`.** `monitrs snapshot --format json` reports
+  `"schema_version": 2`, and a consumer that checks it — which is what the field is for —
+  will now refuse rather than misread. Two fields were **removed**:
+  `sensors.battery.health` and `sensors.temperatures[].high_celsius`. The second's
+  replacement, `peak_celsius`, deliberately means something else, so a script reading the
+  old name as a declared limit would have silently reinterpreted a high-water mark as one.
+  The old `health` is `capacity.full_microwatt_hours / capacity.design_microwatt_hours`.
+  Added, which alone would not have earned a bump: `cpu.cgroup_quota`, `cpu.core_classes`,
+  `memory.cgroup_used_bytes`, `filesystems[].inodes`,
+  `sensors.battery.{capacity, temperature_celsius, power_watts}`, and
+  `host.environment.available.container` on Linux.
+* **Six public enums gained variants**, and none of them is `#[non_exhaustive]`, so a
+  downstream `match` no longer compiles until it grows an arm:
+  `monitrs_core::process::ProcessPredicate::InSubtree`, `monitrs_tui::ViewId::{Cpu, Battery}`,
+  `monitrs_tui::Action::{FollowSelected, StopFollowing}`, `monitrs_tui::Effect::RingBell`,
+  `monitrs_tui::app::Command::{Follow, Unfollow}`, and
+  `monitrs_tui::app::NoticeKind::Pressure`. Two public constants changed type as a
+  consequence: `ViewId::ALL` is now `[ViewId; 7]` and `NoticeKind::ALL` is `[NoticeKind; 8]`,
+  so a spelled-out array length fails to compile.
+
+  These types stay exhaustive on purpose. `Effect` in particular is matched without a
+  wildcard in the one function that acts on the outside world, and that exhaustiveness is
+  what forces a new effect to be wired to something real instead of silently doing nothing.
+* **Nine public fields were added to seven public structs**, breaking struct literals.
+  Four have no `Default`, so *every* literal breaks: `HostEnvironment::container`,
+  `FilesystemSnapshot::inodes`, `ProcessDetail::open_file_list`, and
+  `macos::MachineFacts::core_classes`. Three have one, so only fully exhaustive literals
+  break: `Scenario::{asymmetric_cores, process_open_files, battery_state}`,
+  `linux::LinuxSources::power_supplies`, and `app::AppSettings::bell_on_critical`. Add to
+  those `CpuSnapshot::{cgroup_quota, core_classes}`, `MemorySnapshot::cgroup_used_bytes`,
+  and `BatterySnapshot::{capacity, temperature_celsius, power_watts}`.
+* **The screens renumbered, so `ViewId::to_digit` and `ViewId::from_digit` answer
+  differently.** Inserting CPU at `3` moved Storage to `4`, Network to `5` and Inspect to
+  `6`; `5` now opens Network for anyone with the old key in their fingers or their scripts.
+* **Below 92 columns the tab strip shows bare digits instead of screen names** — `[1] 2 3 4
+  5 6 7` rather than `[1 Overview] 2 Processes …`. Seven titles need 76 cells beside the
+  footer hints, where five needed 58, so an 80-column terminal that used to show the names
+  no longer can. While the timeline is frozen the footer carries `L live` too and the
+  cutover rises to 100 columns, which reaches into the Standard band. The active screen
+  stays bracketed, and §5.2's rule that colour is never the only carrier still holds.
 
 ### Fixed
+
+* **Storage listed one row per mount point rather than per device**, so an APFS Mac showed
+  the same disk four times with four identical throughput figures — and a reader adding
+  them up got four times the machine's real I/O. One row per device now, with every mount
+  point it backs named in the row.
 
 * **`OPEN FILES` on macOS was the descriptor table size, not the count.** A process
   reporting 25 held 3 descriptors, opened 20 more, and still reported 25; another reporting
@@ -157,6 +209,46 @@ It had two panels and thirty blank rows. It now has four.
   on the machine this was found on.
 * **A failed `cpu.max` read kept the previous value**, presenting a ceiling read minutes
   earlier as the current one. An unparsable limit is now unavailable.
+* **`cargo doc` was broken on Linux** — a public module doc in the new `statfs` reader
+  linked to a private constant — and nothing on a macOS workstation could see it, because
+  neither `cargo check --target` nor `clippy --target` runs rustdoc. The release checklist
+  now runs all three against the other platform.
+* **Three documents still sent the reader to `5` for the Inspect screen** after the
+  renumbering: the README, the troubleshooting guide and the accessibility review.
+* **The command palette's `view` hint and its rejection message listed only the five 0.1.0
+  screens**, so `cpu` and `battery` worked but were undiscoverable. The rejection now names
+  every screen, and a test walks `ViewId::ALL` so the next screen cannot be added without
+  one.
+
+### Known limitations
+
+Carried forward and re-checked rather than copied: what 0.1.0 listed and this release still
+owes, minus what is now fixed.
+
+* **The twelve-hour soak is still not on record**, and it is now explicitly out of scope
+  here: it will be run on a dedicated EC2 host under its own project rather than on a
+  workstation, because the gate §16.1 asks for is twelve uninterrupted hours and a laptop
+  that sleeps does not produce one. The 30-minute run with the shipped collector remains
+  the only evidence, and it showed no growth. **Nothing has been soaked on Linux**, which
+  is also the only configuration where the file-descriptor budget is exercised at all.
+* **Idle self-CPU still misses its p95 budget**: median 0.5–1.1% against 1% — met — and p95
+  6–11% against 2%. `docs/benchmarks.md` locates the cost read by read; it is OS reads
+  rather than monitrs' own computation.
+* **Two of the seven screens have never been seen on Linux.** The Battery screen's Linux
+  collector is tested from captured `/sys/class/power_supply` fixtures on macOS, and the
+  inode reader from `statfs` errno cases, but no Linux machine has run either.
+* A slow terminal can still block a frame for an unbounded time, and no instrument here can
+  see it.
+* **Below 92 columns the tab strip loses the screen names**, which is new in this release
+  and is the cost of going from five screens to seven.
+* Device busy time remains unsupported on macOS: there is no documented API. Per-process
+  socket counts, which 0.1.0 listed here, are now supported — one syscall already carried
+  them.
+* PSI is Linux-only, and says `n/a` on macOS rather than promising a value that will never
+  arrive.
+* Timestamps are UTC and labelled `Z`: no time-zone database is bundled.
+* Of the six published archives, only the two macOS ones have ever been run, and the
+  x86_64 one only under Rosetta. That is unchanged from 0.1.0.
 
 ## [0.1.0] - 2026-07-30
 
@@ -306,5 +398,6 @@ Named because §16.1's own last line asks for measurement rather than claims:
   the Rust ecosystem norm and this project's dependency licence policy. Anyone who
   cloned the repository at its first commit saw the earlier licence.
 
-[Unreleased]: https://github.com/gaborini/monitrs/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/gaborini/monitrs/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/gaborini/monitrs/releases/tag/v0.2.0
 [0.1.0]: https://github.com/gaborini/monitrs/releases/tag/v0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1113,7 +1113,7 @@ dependencies = [
 
 [[package]]
 name = "monitrs"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "clap",
  "clap_complete",
@@ -1140,7 +1140,7 @@ dependencies = [
 
 [[package]]
 name = "monitrs-collectors"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "libc",
  "monitrs-core",
@@ -1150,7 +1150,7 @@ dependencies = [
 
 [[package]]
 name = "monitrs-core"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "proptest",
  "serde",
@@ -1160,7 +1160,7 @@ dependencies = [
 
 [[package]]
 name = "monitrs-tui"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "crossterm",
  "insta",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 # MSRV. Raised to 1.95 by `sysinfo` 0.39, which is the highest floor in the
 # resolved graph. Verified by the `msrv` CI job, not by assumption.
@@ -22,9 +22,9 @@ categories = ["command-line-utilities"]
 
 [workspace.dependencies]
 # --- internal ---
-monitrs-core = { version = "0.1.0", path = "crates/monitrs-core" }
-monitrs-collectors = { version = "0.1.0", path = "crates/monitrs-collectors" }
-monitrs-tui = { version = "0.1.0", path = "crates/monitrs-tui" }
+monitrs-core = { version = "0.2.0", path = "crates/monitrs-core" }
+monitrs-collectors = { version = "0.2.0", path = "crates/monitrs-collectors" }
+monitrs-tui = { version = "0.2.0", path = "crates/monitrs-tui" }
 
 # --- terminal ---
 # `crossterm_0_29` is ratatui 0.30's compatibility feature. Pinning it here is

--- a/README.md
+++ b/README.md
@@ -7,12 +7,14 @@ terminal monitors, what it was doing thirty seconds ago. Pause the timeline,
 scrub back to a spike, and see which processes were most strongly correlated
 with it.
 
-> **Status: `0.1.0`, and marked a pre-release.** It is on
+> **Status: `0.2.0`, and marked a pre-release.** It is on
 > [crates.io](https://crates.io/crates/monitrs) and
-> [GitHub](https://github.com/gaborini/monitrs/releases/tag/v0.1.0). The pre-release
-> flag is not modesty: two of §16.1's budgets are not met and the twelve-hour soak has
-> not been run, both of which are stated in [`CHANGELOG.md`](CHANGELOG.md) and in the
-> table below. Where a claim has a caveat, the caveat is next to it rather than left out.
+> [GitHub](https://github.com/gaborini/monitrs/releases/tag/v0.2.0). The pre-release
+> flag is not modesty: one of §16.1's budgets is not met — idle self-CPU at the 95th
+> percentile — and the twelve-hour soak has not been run, both of which are stated in
+> [`CHANGELOG.md`](CHANGELOG.md) and in the table below. `0.2.0` also changes the
+> library API and the JSON export schema; the changelog lists every break. Where a claim
+> has a caveat, the caveat is next to it rather than left out.
 
 ## Demo
 
@@ -166,7 +168,7 @@ Windows is not supported and is not planned for v1.
 
 Support is tracked **per metric**, not per platform. See
 [`docs/platform-support.md`](docs/platform-support.md) for which metrics each
-platform provides, and the Inspect screen (`5`) for what your specific machine
+platform provides, and the Inspect screen (`6`) for what your specific machine
 provides right now.
 
 ## Install
@@ -191,7 +193,7 @@ surprises you.
 
 ### From a release archive
 
-[The `v0.1.0` release](https://github.com/gaborini/monitrs/releases/tag/v0.1.0) has one
+[The `v0.2.0` release](https://github.com/gaborini/monitrs/releases/tag/v0.2.0) has one
 archive per target — `x86_64` and `aarch64` for Linux glibc, Linux musl, and macOS —
 each carrying the binary, both licences, this README, the changelog excerpt for that
 version, shell completions for bash, zsh, fish, PowerShell and elvish, and a manpage.
@@ -199,9 +201,11 @@ Installing one means verifying it and putting the binary somewhere on your `PATH
 
 ```sh
 # Replace the version and target with the archive you downloaded.
-shasum -a 256 -c monitrs-0.1.0-aarch64-apple-darwin.tar.gz.sha256
-tar xzf monitrs-0.1.0-aarch64-apple-darwin.tar.gz
-install -m 755 monitrs-0.1.0-aarch64-apple-darwin/monitrs ~/.local/bin/monitrs
+# The release carries one SHA256SUMS for all six archives, not a file per archive, so
+# --ignore-missing is what lets you check the one you actually downloaded.
+shasum -a 256 --check --ignore-missing SHA256SUMS     # sha256sum on Linux
+tar xzf monitrs-0.2.0-aarch64-apple-darwin.tar.gz
+install -m 755 monitrs-0.2.0-aarch64-apple-darwin/monitrs ~/.local/bin/monitrs
 ```
 
 Releases also carry a build attestation, so `gh attestation verify

--- a/crates/monitrs-tui/src/app/command.rs
+++ b/crates/monitrs-tui/src/app/command.rs
@@ -30,7 +30,7 @@ use crate::theme::{ColorMode, ThemeId};
 /// A parsed palette command (§6.3's initial list).
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Command {
-    /// `view overview|processes|storage|network|inspect`.
+    /// `view overview|processes|cpu|storage|network|inspect|battery`.
     ChangeView(ViewId),
     /// `sort cpu|memory|read|write|pid|name|age|…`.
     Sort(SortField),
@@ -127,7 +127,7 @@ pub struct CommandHint {
 /// not each need a key, so the list has to be complete and readable.
 pub const HINTS: &[CommandHint] = &[
     CommandHint {
-        usage: "view <overview|processes|storage|network|inspect>",
+        usage: "view <overview|processes|cpu|...>",
         completion: "view ",
         summary: "switch to a main view",
     },
@@ -231,7 +231,7 @@ pub fn parse(line: &str) -> Result<Command, CommandError> {
                 .ok_or_else(|| CommandError::BadArgument {
                     command: "view",
                     value: argument.to_owned(),
-                    expected: "one of overview, processes, storage, network, inspect",
+                    expected: "one of overview, processes, cpu, storage, network, inspect, battery",
                 })
         }
         "sort" => {
@@ -649,6 +649,39 @@ mod tests {
                 "{} does not complete towards {}",
                 hint.completion,
                 hint.usage
+            );
+        }
+    }
+
+    #[test]
+    fn every_screen_is_reachable_by_name_from_the_palette() {
+        // §6.3 exists for discoverability, so a screen the palette cannot name is a screen
+        // that only exists for whoever already knows the digit. Asserted over `ViewId::ALL`
+        // rather than a written-out list, so adding a screen fails here until its token
+        // parses — which is what the two 0.2.0 screens needed and did not have.
+        for view in ViewId::ALL {
+            let line = format!("view {}", view.palette_token());
+            assert_eq!(
+                parse(&line),
+                Ok(Command::ChangeView(view)),
+                "{line:?} must select {view:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn the_rejection_for_an_unknown_screen_names_every_screen_there_is() {
+        // The error is the only exhaustive list a user sees: the hint's usage string is
+        // abridged because spelling all seven out costs the panel its summary column.
+        let Err(error) = parse("view nosuchscreen") else {
+            panic!("an unknown screen must be refused");
+        };
+        let text = error.to_string();
+        for view in ViewId::ALL {
+            assert!(
+                text.contains(view.palette_token()),
+                "{:?} is missing from {text:?}",
+                view.palette_token()
             );
         }
     }

--- a/crates/monitrs-tui/tests/snapshots/overlay_snapshots__command_palette_ascii.snap
+++ b/crates/monitrs-tui/tests/snapshots/overlay_snapshots__command_palette_ascii.snap
@@ -8,17 +8,17 @@ expression: text_of(&buffer)
 |+ COMMAND ----------------------------------------------------------------------------- 13 commands ---+|
 ||:                                                                                                     ||
 ||------------------------------------------------------------------------------------------------------||
-||> view <overview|processes|storage|network|inspect>  switch to a main view                            ||
-||  sort <cpu|memory|read|write|pid|name|age>          order the process table by a column              ||
-||  filter <text>                                      match name, command, PID or user; empty clears   ||
-||  interval <duration>                                set the sample interval, such as 500ms or 2s     ||
-||  history <duration>                                 set the retained history span, such as 5m        ||
-||  theme <default-dark|default-light|high-contrast>   select a built-in theme                          ||
-||  glyphs <auto|unicode|ascii>                        select the glyph set                             ||
-||  color <auto|truecolor|256|16|off>                  select the colour depth                          ||
-||  export snapshot <path>                             write a redacted JSON snapshot                   ||
-||  config path                                        show where configuration is read from            ||
-||  reload config                                      re-read the configuration file                   ||
-||  follow [pid]                                       scope the table to one process and its descend...||
-||  unfollow                                           show every process again                         ||
+||> view <overview|processes|cpu|...>                 switch to a main view                             ||
+||  sort <cpu|memory|read|write|pid|name|age>         order the process table by a column               ||
+||  filter <text>                                     match name, command, PID or user; empty clears    ||
+||  interval <duration>                               set the sample interval, such as 500ms or 2s      ||
+||  history <duration>                                set the retained history span, such as 5m         ||
+||  theme <default-dark|default-light|high-contrast>  select a built-in theme                           ||
+||  glyphs <auto|unicode|ascii>                       select the glyph set                              ||
+||  color <auto|truecolor|256|16|off>                 select the colour depth                           ||
+||  export snapshot <path>                            write a redacted JSON snapshot                    ||
+||  config path                                       show where configuration is read from             ||
+||  reload config                                     re-read the configuration file                    ||
+||  follow [pid]                                      scope the table to one process and its descendants||
+||  unfollow                                          show every process again                          ||
 |+------------------------------------------------------------------------------------------------------+|

--- a/crates/monitrs-tui/tests/snapshots/overlay_snapshots__command_palette_unicode.snap
+++ b/crates/monitrs-tui/tests/snapshots/overlay_snapshots__command_palette_unicode.snap
@@ -8,17 +8,17 @@ expression: text_of(&buffer)
 |┌ COMMAND ───────────────────────────────────────────────────────────────────────────── 13 commands ───┐|
 |│:                                                                                                     │|
 |│──────────────────────────────────────────────────────────────────────────────────────────────────────│|
-|│  view <overview|processes|storage|network|inspect>  switch to a main view                            │|
-|│  sort <cpu|memory|read|write|pid|name|age>          order the process table by a column              │|
-|│▸ filter <text>                                      match name, command, PID or user; empty clears   │|
-|│  interval <duration>                                set the sample interval, such as 500ms or 2s     │|
-|│  history <duration>                                 set the retained history span, such as 5m        │|
-|│  theme <default-dark|default-light|high-contrast>   select a built-in theme                          │|
-|│  glyphs <auto|unicode|ascii>                        select the glyph set                             │|
-|│  color <auto|truecolor|256|16|off>                  select the colour depth                          │|
-|│  export snapshot <path>                             write a redacted JSON snapshot                   │|
-|│  config path                                        show where configuration is read from            │|
-|│  reload config                                      re-read the configuration file                   │|
-|│  follow [pid]                                       scope the table to one process and its descendan…│|
-|│  unfollow                                           show every process again                         │|
+|│  view <overview|processes|cpu|...>                 switch to a main view                             │|
+|│  sort <cpu|memory|read|write|pid|name|age>         order the process table by a column               │|
+|│▸ filter <text>                                     match name, command, PID or user; empty clears    │|
+|│  interval <duration>                               set the sample interval, such as 500ms or 2s      │|
+|│  history <duration>                                set the retained history span, such as 5m         │|
+|│  theme <default-dark|default-light|high-contrast>  select a built-in theme                           │|
+|│  glyphs <auto|unicode|ascii>                       select the glyph set                              │|
+|│  color <auto|truecolor|256|16|off>                 select the colour depth                           │|
+|│  export snapshot <path>                            write a redacted JSON snapshot                    │|
+|│  config path                                       show where configuration is read from             │|
+|│  reload config                                     re-read the configuration file                    │|
+|│  follow [pid]                                      scope the table to one process and its descendants│|
+|│  unfollow                                          show every process again                          │|
 |└──────────────────────────────────────────────────────────────────────────────────────────────────────┘|

--- a/crates/monitrs/src/export.rs
+++ b/crates/monitrs/src/export.rs
@@ -43,7 +43,20 @@ use serde::Serialize;
 ///
 /// Bumped whenever a field is removed or its meaning changes, so a consumer can
 /// refuse an export it does not understand rather than misread it.
-pub(crate) const SCHEMA_VERSION: u32 = 1;
+///
+/// `2` since 0.2.0. Two fields were **removed** — `sensors.battery.health` and
+/// `sensors.temperatures[].high_celsius` — and the second's replacement,
+/// `peak_celsius`, deliberately means something different: the old name claimed a
+/// declared threshold and the value was a high-water mark. A script that read
+/// `high_celsius` as a limit would misread `peak_celsius` as one, which is exactly
+/// what this constant exists to prevent. Deriving the old `health` needs the two
+/// figures in `sensors.battery.capacity`: `full_microwatt_hours / design_microwatt_hours`.
+///
+/// Fields were also added, which alone would not have justified a bump: `cpu.cgroup_quota`,
+/// `cpu.core_classes`, `memory.cgroup_used_bytes`, `filesystems[].inodes`,
+/// `sensors.battery.{capacity, temperature_celsius, power_watts}`, and
+/// `host.environment.available.container` on Linux.
+pub(crate) const SCHEMA_VERSION: u32 = 2;
 
 /// What may appear in an export.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -515,7 +528,7 @@ mod tests {
         let json = SnapshotExport::new(&snapshot, RedactionPolicy::default())
             .to_json()
             .expect("serializes");
-        assert!(json.contains("\"schema_version\": 1"));
+        assert!(json.contains("\"schema_version\": 2"));
         assert!(json.contains(env!("CARGO_PKG_VERSION")));
         assert!(json.contains("monitrs"));
     }
@@ -532,7 +545,8 @@ mod tests {
             parsed
                 .get("schema_version")
                 .and_then(serde_json::Value::as_u64),
-            Some(1)
+            Some(u64::from(SCHEMA_VERSION)),
+            "the parsed version must be the declared one, so a bump cannot be half-applied"
         );
         assert!(
             parsed

--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -626,7 +626,7 @@ machine with high memory use. This matches §5.7, which lists the Compact band's
 contents and does not include pressure, but for an accessibility review it is the
 most consequential thing lost on a small terminal.
 
-Reachable instead: `5` opens Inspect, whose `PRESSURE` section lists every
+Reachable instead: `6` opens Inspect, whose `PRESSURE` section lists every
 non-normal signal with its symbol, its state, and the rule that derived it, and
 which does fit at 80×24. **Not changed** — spending a header cell on a severity
 badge is a layout decision beyond a review's remit — but the concrete fix is small:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -142,7 +142,7 @@ enum Effect {
     None, RequestRedraw,
     FetchProcessDetail(ProcessIdentity),
     SignalProcess { identity: ProcessIdentity, signal: SignalKind },
-    ReloadConfig, ExportSnapshot(PathBuf), Shutdown,
+    ReloadConfig, ExportSnapshot(PathBuf), RingBell, Shutdown,
 }
 ```
 

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -275,7 +275,7 @@ components and 21 interfaces:
 
 | Read | Cost | Tier |
 |---|---|---|
-| `sysinfo` process refresh | 29 ms | fast |
+| `sysinfo` process refresh | 29 ms | ~~fast~~ — **fixed**, see below |
 | `Disks::refresh(false)` | 34 ms wall, ~21 ms of it our own CPU | ~~fast~~ — **fixed**, see below |
 | `Disks::refresh_specifics(io_usage)` | ~1 ms CPU | fast |
 | `Disks::refresh(true)` | 25 ms | medium |
@@ -295,7 +295,7 @@ Averaged that is 1.7% of a core, but it arrives as one spike in the second it la
 a p95 taken once a second sees the spike. Nothing has been measured about whether that
 read can be made cheaper, so it is the next thing to look at rather than a conclusion.
 
-Three things follow, and none of them is a micro-optimisation:
+Two things follow, and neither is a micro-optimisation:
 
 1. **Asking `sysinfo` for fewer process fields does not help — but not asking at all
    does.** *Fixed.* Requesting `ProcessRefreshKind::nothing()` still costs 26 ms of the
@@ -339,16 +339,13 @@ Three things follow, and none of them is a micro-optimisation:
    stopwatch and nothing like each other on the meter §16.1 actually budgets. The
    collection figures above are wall-clock and barely moved; the idle-CPU figure
    halved.
-3. **On macOS the process table is enumerated twice.** The native layer walks
-   `kern.proc.all` itself and then overwrites the baseline's table; `sysinfo`'s 29 ms
-   walk survives only to supply command lines and user names. Sourcing those natively
-   too — the macOS layer already has `read_process_arguments` — would remove most of
-   the fast tick's cost. That is the one change with a real chance of reaching the 1%
-   budget, and it is not a small one: the merge semantics that keep a refused read
-   reported as refused rather than as zero all live in that path.
 
-Until that is done, the honest statement is the one in the table: five budgets are
-met, idle CPU is not, and the reason is measured rather than guessed.
+The honest statement is the one in the table, row by row: four budgets pass outright, the
+descriptor budget passes over half an hour rather than the twelve the gate asks for, the
+idle-CPU **median** now passes and its **p95** does not — 6–11% against 2%, arriving as the
+medium tier's 85 ms `Components::refresh` once every five seconds — and two rows have no
+measurement to pass or fail. The reason for the p95 is measured rather than guessed, and
+whether that read can be made cheaper is the open question, not which read it is.
 
 ## What is not measured yet
 

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -4,24 +4,35 @@ Everything needed to cut a monitrs release, in order, written for someone who ha
 never done it. Follow it top to bottom. Nothing here is optional except where it
 says so.
 
-## Read this first: `0.1.0` is not releasable yet
+## Read this first: what this project still owes
 
 **The interface launches**, and the §23 verbs — launch, monitor, filter, inspect,
 pause, seek, return live, quit — have each been exercised by hand in a real
 terminal. So has the renice flow, by `scripts/verify-renice.py`: it drives the real
 binary on a pty, presses `R` on a process it started itself, and then asks `ps` —
-not monitrs — whether the value changed. What is still missing before `0.1.0`:
+not monitrs — whether the value changed.
 
-* **No twelve-hour soak is on record.** A 30-minute run with the shipped collector
+`0.1.0` and `0.2.0` are both published, as pre-releases, with the items below still
+open. That was a deliberate call each time rather than an oversight, and the point of
+this section is that the open items travel with the release instead of being forgotten:
+they are repeated in each `CHANGELOG.md` release section under *Known limitations*, which
+is what a user actually reads. What is still owed:
+
+* **No twelve-hour soak is on record**, and it is not going to be produced from a
+  workstation: the gate is twelve uninterrupted hours, and a laptop that sleeps does not
+  yield one. It is being moved to a dedicated EC2 host under its own project. A 30-minute
+  run with the shipped collector
   is ([`soak-testing.md`](soak-testing.md#runs-on-record)): resident size fell over
   the run, descriptors stayed at 3, retained history stayed bounded with the ring
   full, and nothing was dropped even with the channel saturated. That is evidence,
   not the gate — §16.1 says twelve hours. (The 90 ms worst-case input latency that run
   reported turned out to be the harness measuring two thread wake-ups rather than
   monitrs; see [`soak-testing.md`](soak-testing.md).)
-* **The idle self-CPU budget of §16.1 is not met.** Measured on a 12-core Mac with
-  about a thousand processes: median 1.3–2.7%, p95 11–15%, against a budget of 1% and
-  2%. The median is close; the p95 is not.
+* **The idle self-CPU budget of §16.1 is half met.** Measured on a 12-core Mac with
+  about a thousand processes: median **0.5–1.1%** against a 1% budget, which passes, and
+  p95 **6–11%** against 2%, which does not. (This list previously quoted 1.3–2.7% and
+  11–15%, which were the figures from partway through the fix and were already superseded
+  in [`benchmarks.md`](benchmarks.md) when they were written here.)
   The other five measurable budgets pass — frame render, input latency, collection
   p95, resident memory, descriptor growth — and
   [`benchmarks.md`](benchmarks.md#the-161-end-to-end-budgets) has the numbers, the
@@ -31,8 +42,9 @@ not monitrs — whether the value changed. What is still missing before `0.1.0`:
 * **The release notes are written** — `CHANGELOG.md` has a `0.1.0` section and
   `changelog_excerpt.py` extracts it — but **the date in its heading is
   `2026-07-30`**. Keep a Changelog dates a section by its release date, so if the tag
-  is pushed on another day, change that line first. The workflow's `verify` job does
-  not check the date, only that the section exists.
+  is pushed on another day, change that line first. The workflow's `verify` job passes
+  `--check-date`, which *warns* on a heading that is not dated today rather than failing —
+  a hard check there would only teach people to backdate the heading.
 
   Done for `v0.1.0`: six archives and a `SHA256SUMS` are on the release page, every
   checksum verifies against the *downloaded* files, and every archive carries a build
@@ -77,9 +89,16 @@ gh --version             # for verifying the published artifacts
 You also need:
 
 * push access to the repository, including tags;
-* nothing else. **No publishing token belongs on your machine or in this
-  repository** (§18.4). The release workflow uses the run's own `GITHUB_TOKEN`, and
-  crates.io publication is not part of `0.1.0` (§19.3).
+* a crates.io token, for step 10 only, and **only for as long as that step takes**.
+  §18.4 still says no publishing token belongs in this repository or in a workflow: the
+  release workflow uses the run's own `GITHUB_TOKEN` and never publishes crates. Obtain
+  the token, `cargo login` with it, publish, then `cargo logout`. Do not paste it into a
+  terminal that keeps scrollback, a chat window, or a shell history file — a token that
+  has been seen anywhere else is a token to revoke.
+
+Since `0.1.0`, crates.io publication **is** part of a release: all four crates are
+published, and the README tells users to `cargo install monitrs --locked`. Step 10 is
+where that happens; it is deliberately the last step, after the tag is proven.
 
 Optional: `just`, a thin wrapper around the cargo commands below. Every recipe
 prints the command it runs, and this checklist gives the underlying commands so
@@ -92,11 +111,14 @@ prints the command it runs, and this checklist gives the underlying commands so
   `v0.1.0-rc.1` also triggers it.
 * Anything `0.x` is published as a **pre-release** automatically, so nobody mistakes
   it for a stability promise.
-* Do **not** publish to crates.io until the name and metadata are final (§19.1).
+* §19.1's rule was **do not publish to crates.io until the name and metadata are
+  final**. They are: the four crate names are taken and the metadata shipped with
+  `0.1.0`, so every release from now on publishes (step 10). Renaming a published crate
+  is not possible, which is what that rule was protecting.
 
 ## 2. Bump the version
 
-The version lives in **exactly four places**, and three of them are one file. Every
+The version lives in **exactly five places**, and three of them are one file. Every
 crate uses `version.workspace = true`, so no per-crate manifest is touched.
 
 1. `Cargo.toml`, `[workspace.package]`:
@@ -127,6 +149,14 @@ crate uses `version.workspace = true`, so no per-crate manifest is touched.
    than silently building something else.
 
 4. `CHANGELOG.md` — the next step.
+
+5. `README.md` — the status banner, the release link, and the three hard-coded archive
+   filenames in the install snippet. This one is easy to miss and expensive to miss:
+   `.github/workflows/release.yml` copies `README.md` into **every** archive, and
+   `crates/monitrs/Cargo.toml` sets `readme = "../../README.md"`, so a stale banner
+   becomes the crates.io landing page for the new version. Nothing in CI checks it.
+   Include it in the release commit at step 7 so the tagged commit the archives are
+   built from already carries it.
 
 Confirm what the tooling now sees. This is the exact command the release workflow
 compares against your tag:
@@ -159,11 +189,12 @@ release with empty notes is prevented:
 python3 .github/scripts/changelog_excerpt.py X.Y.Z
 ```
 
-Today, with only an `Unreleased` section, it correctly fails:
+It fails for a version with no section, which is how a release with empty notes is
+prevented. Try it with a version you have not written yet:
 
 ```text
-$ python3 .github/scripts/changelog_excerpt.py 0.1.0
-CHANGELOG.md has no section for 0.1.0
+$ python3 .github/scripts/changelog_excerpt.py 9.9.9
+CHANGELOG.md has no section for 9.9.9
 $ echo $?
 1
 ```
@@ -191,10 +222,29 @@ cargo test --workspace --all-features -- --ignored --test-threads=1
 That pass includes the platform smoke tests **and** the soak harness at its default
 ten seconds. Ten seconds is not the soak gate; step 5 is.
 
+**It also rewrites tracked files.** `crates/monitrs/tests/capture.rs` writes a fresh frame
+for every screen into `docs/screenshots/`, so a clean tree is dirty afterwards, with seven
+files changed. That is the point — §20.1 allows no screenshot that is not written from the
+renderer — but decide deliberately whether the new frames belong in the release:
+
+```sh
+git status --porcelain docs/screenshots/
+git diff docs/screenshots/          # a captured frame from your machine, not a diff to review line by line
+```
+
+Either commit them with the release or `git restore docs/screenshots/`. Do not leave them
+uncommitted: the next `git add -A` picks them up in whatever commit comes along.
+
 Also confirm the dependency graph has not drifted:
 
 ```sh
-cargo tree -p crossterm --workspace     # exactly one crossterm major version (§13)
+# The real check, and the one CI gates on: it must print exactly one version.
+cargo metadata --format-version 1 --all-features \
+  | python3 .github/scripts/crate_versions.py crossterm
+
+# For reading the graph by eye. `-p` cannot select crossterm — it is a dependency, not a
+# workspace member — so this exits non-zero and CI wraps it in `|| true`. Informational.
+cargo tree --workspace --all-features -i crossterm
 ```
 
 ### And the platform you are not on
@@ -291,7 +341,7 @@ Distribution:
 
 ```sh
 git switch -c release/vX.Y.Z
-git add Cargo.toml Cargo.lock CHANGELOG.md
+git add Cargo.toml Cargo.lock CHANGELOG.md README.md
 git commit -m "release: vX.Y.Z"
 ```
 
@@ -415,13 +465,62 @@ tar tzf monitrs-X.Y.Z-<target>.tar.gz
 * [ ] the release body contains the changelog section, not the whole file;
 * [ ] a `0.x` release is marked pre-release.
 
-## 10. After publishing
+## 10. Publish to crates.io
+
+Last, and only after the tag and its archives are verified: crates.io publication cannot be
+undone. A version can be **yanked**, which stops new dependents from selecting it, but the
+files stay downloadable forever and the version number can never be reused.
+
+The four crates publish in dependency order, because each is verified by building it
+against the registry copies of the others:
+
+```
+monitrs-core  ->  monitrs-collectors  ->  monitrs-tui  ->  monitrs
+```
+
+`cargo publish --workspace` does that ordering, and the index wait between crates, itself:
+
+```sh
+cargo login                     # paste the token at the prompt, not on the command line
+cargo publish --workspace --locked --dry-run
+cargo publish --workspace --locked
+cargo logout
+```
+
+Three rules:
+
+* **The token never appears in `argv`.** `cargo publish --token <value>` puts it in the
+  process table, where every other user on the machine can read it. `cargo login` prompts.
+* **`--dry-run` first.** It packages and verifies every crate without uploading, which
+  catches an excluded file, an oversized package, or a dependency that is not published.
+* **`cargo logout` afterwards.** The token lands in `~/.cargo/credentials.toml` in plain
+  text; there is no reason for it to outlive the release.
+
+Then verify what the registry actually serves, in an empty directory, from the registry
+rather than from your checkout:
+
+```sh
+cargo install monitrs --locked --version X.Y.Z --root /tmp/monitrs-verify
+/tmp/monitrs-verify/bin/monitrs --version
+```
+
+* [ ] all four crates show the new version on crates.io;
+* [ ] `docs.rs` built the documentation for each — a failed docs.rs build is invisible from
+      here and is the most common thing to go wrong after a successful publish;
+* [ ] `cargo install monitrs --locked` fetches and builds the new version.
+
+## 11. After publishing
 
 * [ ] `CHANGELOG.md` on `main` has an empty `Unreleased` section again.
 * [ ] Any documentation that names a version matches.
-* [ ] Installation methods documented in the README actually work for this release:
-      the archives, and `cargo install monitrs --locked` **only once crates.io
-      publication has happened** (§19.3 — not for `0.1.0`).
+* [ ] Installation methods documented in the README actually work for this release —
+      run them, from a downloaded archive, in an empty directory:
+      * the checksum command in the README must name `SHA256SUMS`. The workflow
+        concatenates the per-archive `.sha256` files into that one file and then `rm -f
+        ./*.sha256`, so a README telling the reader to check
+        `monitrs-X.Y.Z-<target>.tar.gz.sha256` sends them to a file the release does not
+        carry. That was true of `0.1.0`'s README for its whole life.
+      * `cargo install monitrs --locked`, which step 10 has just verified.
 * [ ] A Homebrew tap is a later step, deliberately: §19.3 says after the release
       process has stabilised. One release is not stability.
 * [ ] Deb, RPM, Nix and other packaging are later milestones and must not block a
@@ -440,7 +539,7 @@ A published release cannot be un-published safely. The remedy is always forward.
 4. Record the defect in `CHANGELOG.md` under the new version, and say which version
    was withdrawn.
 
-## The §23 gate for 0.1.0
+## The §23 gate
 
 §23's list, verbatim, as a checklist. `0.1.0` may not be tagged until every box is
 ticked with evidence — a test, a recorded measurement, or a named machine.
@@ -467,9 +566,10 @@ ticked with evidence — a test, a recorded measurement, or a named machine.
       and aarch64 in glibc and musl, macOS on both architectures. macOS x86_64 is a
       cross-compile because GitHub's Intel runners are being retired, so CI builds it
       and does not run it.
-- [x] **release archives and checksums are published.** The workflow does this; it
-      has not yet run for a real tag. The `aarch64-apple-darwin` archive has been
-      assembled and exercised by hand (step 8 below).
+- [x] **release archives and checksums are published.** The workflow has run for a real
+      tag: `v0.1.0` has six archives and a `SHA256SUMS` on its release page, every
+      checksum verified against the downloaded files, and every archive carrying a build
+      attestation that `gh attestation verify` accepts.
 - [ ] **default settings remain below the memory and CPU budgets on the reference
       workload.** Frame time, input latency, collection p95, resident memory,
       descriptor growth **and the idle-CPU median** are measured and pass. The
@@ -483,8 +583,8 @@ ticked with evidence — a test, a recorded measurement, or a named machine.
       measurement.** §20.1's required contents are all present: the demo frame is
       real and reproducible, every performance figure links to the file that produced
       it, and the row that fails its budget is in the same table as the ones that
-      pass. What remains unverifiable until a release exists is the install
-      instructions for the five archives nobody has run.
+      pass. What remains unverified is the install instructions for the four archives
+      nobody has run — the two macOS ones have been run from the published tarball.
       §20.1's list, all present and checked: value proposition, a real captured
       frame, honest differentiation, supported platforms, install methods,
       keybindings, configuration path, the metric-semantics warning, the privilege

--- a/docs/soak-testing.md
+++ b/docs/soak-testing.md
@@ -252,10 +252,13 @@ Be exact about this; §23 asks for claims to be supported by a test or a documen
 measurement, and these are neither yet.
 
 * **The interactive runtime is not soaked.** The renderer, the terminal guard, and
-  the input thread are absent — the input thread because `crossterm::event::poll`
-  needs a real tty, and the renderer because there is no assembled event loop to
-  drive yet. So §16.1's *idle CPU*, *frame time*, and *no redraw busy loop* budgets
-  are **not** measured here. They need a `monitrs` that launches.
+  the input thread are absent from *this harness* — the input thread because
+  `crossterm::event::poll` needs a real tty. So §16.1's *idle CPU*, *frame time*, and *no
+  redraw busy loop* budgets are **not** measured here. They are measured elsewhere now
+  that `monitrs` launches: idle CPU by `scripts/measure-overhead.py` against the real
+  binary on a pty, and frame time by `crates/monitrs/tests/capture.rs` — see
+  [`benchmarks.md`](benchmarks.md#the-161-end-to-end-budgets). What no instrument covers
+  is the two of them *over twelve hours*, which is what the soak is for.
 * **Descriptors are flat on macOS by construction**, in both modes. The macOS
   collector reads through `sysctl`, `libproc`, mach routines and `getifaddrs`, and
   opens no file at all (see [`platform-support.md`](platform-support.md)). A flat

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -21,7 +21,7 @@ correct, and they are not the same quantity.
   71% available are the same measurement from opposite ends.
 
 The Overview's radar column is too narrow to spell out `available`, which is what
-makes the pair read as a contradiction. Press `5` for **Inspect**, where each signal
+makes the pair read as a contradiction. Press `6` for **Inspect**, where each signal
 is shown with the full rule text that produced it — there the memory row states the
 threshold in terms of available memory explicitly.
 
@@ -336,10 +336,10 @@ different proposition from a laptop at one second. `--history` costs memory in
 proportion to its span; both are clamped to supported ranges and any clamp is
 reported rather than applied silently.
 
-Both are measured now, and one of them **misses its budget**: on a 12-core Mac with
-about a thousand processes, monitrs costs a median 1.3–2.7% of one core at rest against
-a 1% target, while resident memory sits at 29 MiB against 50 MiB and a frame renders in
-200 µs against 16 ms. If your machine runs many processes, expect the CPU figure
+Both are measured now, and one of them **misses half its budget**: on a 12-core Mac with
+about a thousand processes, monitrs costs a median 0.5–1.1% of one core at rest against a
+1% target — which passes — but a p95 of 6–11% against 2%, which does not. Resident memory
+sits at 24.5–26.7 MiB against 50 MiB and a frame renders in 200 µs against 16 ms. If your machine runs many processes, expect the CPU figure
 rather than the budget:
 [`benchmarks.md`](benchmarks.md#where-the-idle-cpu-goes) breaks the cost down read by
 read — most of it is the OS handing over the process table and the disk counters, not


### PR DESCRIPTION
Two more screens, container awareness, following a process with its children — and, from a
pre-release audit, eleven things that would have shipped wrong.

The audit is why this commit is larger than a version bump. It compiled 0.1.0-era code
against HEAD's rlib to find out what actually breaks, and the answer was more than the
changelog said:

* **The JSON export schema was silently incompatible.** `schema_version` was still `1`
  while two fields had been removed — `sensors.battery.health` and
  `sensors.temperatures[].high_celsius` — and the replacement for the second deliberately
  means something else. The constant's own doc comment says to bump it in exactly this
  case, and it is the whole reason a consumer can refuse an export rather than misread one.
  Now `2`, and the round-trip test asserts the parsed value against the constant so a bump
  cannot be half-applied again.
* **Six public enums gained variants and two public constants changed type**
  (`ViewId::ALL` is `[ViewId; 7]`, `NoticeKind::ALL` is `[NoticeKind; 8]`); nine public
  fields were added across seven structs. The changelog named four structs and no enums.
  All of it is listed now, with the four structs that have no `Default` called out, because
  those break every literal rather than only exhaustive ones. The types stay exhaustive on
  purpose — `Effect` is matched without a wildcard in the one function that touches the
  outside world, and that is what forces a new effect to be wired to something real.
* **The palette could not name its own new screens.** `view cpu` and `view battery` parsed,
  but the hint and the rejection message both listed the five 0.1.0 screens, so the two new
  ones were reachable only by digit. The rejection is exhaustive now and a test walks
  `ViewId::ALL`, so the next screen cannot be added without its token parsing.
* **Three documents still sent the reader to `5` for Inspect** after the renumbering moved
  it to `6`: the README, the troubleshooting guide, the accessibility review.
* **The README's first install command named a file the release does not carry.** The
  workflow concatenates the per-archive `.sha256` files into one `SHA256SUMS` and deletes
  them, so `shasum -c monitrs-…tar.gz.sha256` could never have worked for anything
  downloaded from the release page — true for 0.1.0's whole life. It now uses `SHA256SUMS`
  with `--ignore-missing`, which is what the checklist's own verification step uses.

And the release procedure itself was wrong in ways that only bite during a release:

* The checklist opened with "`0.1.0` is not releasable yet" — for a version published a day
  earlier. Its idle-CPU figures were the ones from partway through the fix, already
  superseded in the file it cites as authoritative. Its dependency-drift command exits
  non-zero because `-p` cannot select a dependency, which CI knows and hides behind
  `|| true`. Its worked example claimed a script fails for 0.1.0, which it no longer does.
* **Step 2 said the version lives in "exactly four places".** It lives in five: the README
  carries the status banner, the release link and three hard-coded archive filenames, and
  the workflow copies that README into every archive while `crates/monitrs/Cargo.toml`
  points crates.io at it. Nothing in CI checks it.
* **Nothing in the checklist published to crates.io**, although all four crates are there
  and the README tells people to `cargo install`. 0.1.0 was published by hand, undocumented.
  Step 10 now writes it down: dependency order, `--dry-run` first, the token via `cargo
  login` rather than `argv` where the process table would expose it, and `cargo logout`
  after.
* **Step 4's mandated `--ignored` pass rewrites seven tracked files**, because the capture
  test writes a frame per screen. The step now says so and asks for a decision; this commit
  restores them rather than carrying live-figure churn into a release.

The twelve-hour soak is still not on record, and this release ships without it knowingly:
it is moving to a dedicated EC2 host under its own project, because the gate is twelve
uninterrupted hours and a workstation that sleeps cannot produce one. That, the idle-CPU
p95, and the fact that two of the seven screens have never run on Linux are all in the
0.2.0 changelog's Known limitations, which is where a user looks rather than here.


---
Cutting 0.2.0. The soak is deliberately deferred to a separate EC2 project; recorded in the changelog under Known limitations.